### PR TITLE
Mark all public struct/enum as non_exhaustive

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -12,6 +12,7 @@ use crate::{
     AuditMessage, StatusMessage, StatusMessageBuffer,
 };
 
+#[non_exhaustive]
 pub struct AuditBuffer<T> {
     buffer: T,
 }

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -20,6 +20,7 @@ pub(crate) use netlink_proto::{NetlinkCodec, NetlinkMessageCodec};
 /// - https://github.com/torvalds/linux/blob/b5013d084e03e82ceeab4db8ae8ceeaebe76b0eb/kernel/audit.c#L2386
 /// - https://github.com/mozilla/libaudit-go/issues/24
 /// - https://github.com/linux-audit/audit-userspace/issues/78
+#[non_exhaustive]
 pub struct NetlinkAuditCodec {
     // we don't need an instance of this, just the type
     _private: (),

--- a/src/message.rs
+++ b/src/message.rs
@@ -11,6 +11,7 @@ use netlink_packet_utils::{
 use crate::{constants::*, rules::RuleMessage, AuditBuffer, StatusMessage};
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub enum AuditMessage {
     GetStatus(Option<StatusMessage>),
     SetStatus(StatusMessage),

--- a/src/rules/action.rs
+++ b/src/rules/action.rs
@@ -3,6 +3,7 @@
 use crate::constants::*;
 
 #[derive(Copy, Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub enum RuleAction {
     Never,
     Possible,

--- a/src/rules/buffer.rs
+++ b/src/rules/buffer.rs
@@ -33,6 +33,7 @@ fn BUF(len: usize) -> Field {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub struct RuleBuffer<T> {
     buffer: T,
 }

--- a/src/rules/field.rs
+++ b/src/rules/field.rs
@@ -3,6 +3,7 @@
 use crate::constants::*;
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub enum RuleField {
     Pid(u32),
     Uid(u32),
@@ -55,6 +56,7 @@ pub enum RuleField {
 }
 
 #[derive(Copy, Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub enum RuleFieldFlags {
     BitMask,
     BitTest,

--- a/src/rules/flags.rs
+++ b/src/rules/flags.rs
@@ -3,6 +3,7 @@
 use crate::constants::*;
 
 #[derive(Copy, Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub enum RuleFlags {
     FilterUser,
     FilterTask,

--- a/src/rules/rule.rs
+++ b/src/rules/rule.rs
@@ -12,6 +12,7 @@ use crate::{
 };
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub struct RuleMessage {
     pub flags: RuleFlags,
     pub action: RuleAction,

--- a/src/rules/syscalls.rs
+++ b/src/rules/syscalls.rs
@@ -7,6 +7,7 @@ use netlink_packet_utils::DecodeError;
 use crate::constants::*;
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub struct RuleSyscalls(pub(crate) Vec<u32>);
 
 const BITMASK_BYTE_LEN: usize = AUDIT_BITMASK_SIZE * 4;
@@ -93,6 +94,7 @@ impl RuleSyscalls {
 // FIXME: There is a LOT of copy paste for those iterator implementations...
 // This feels wrong but I could not figure out how to avoid it :(
 
+#[non_exhaustive]
 pub struct RuleSyscallsIter<T> {
     index: u32,
     syscalls: T,

--- a/src/status.rs
+++ b/src/status.rs
@@ -22,6 +22,7 @@ const BACKLOG_WAIT_TIME: Field = 36..40;
 pub const STATUS_MESSAGE_LEN: usize = BACKLOG_WAIT_TIME.end;
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
+#[non_exhaustive]
 pub struct StatusMessage {
     /// Bit mask for valid entries
     pub mask: u32,
@@ -51,6 +52,7 @@ impl StatusMessage {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub struct StatusMessageBuffer<T> {
     buffer: T,
 }


### PR DESCRIPTION
All the public struct/enum in nmstate might add members/type, hence marking
them as non_exhaustive which will prevent API user from in-compatibility
usage.

This allows us to only preserve API compatibility when adding new member to
struct or enum.

Please refer to
https://doc.rust-lang.org/reference/attributes/type_system.html for more
detail.