### PR TITLE
New release 0.5.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,12 @@
+# Changelog
+## [0.5.0] - 2023-01-28
+### Breaking changes
+ - All public struct and enum are marked as `non_exhaustive`. Please check
+   https://doc.rust-lang.org/reference/attributes/type_system.html for more
+   detail. (5660d73)
+
+### New features
+ - N/A
+
+### Bug fixes
+ - N/A

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 authors = ["Corentin Henry <corentinhenry@gmail.com>"]
 name = "netlink-packet-audit"
-version = "0.4.2"
+version = "0.5.0"
 edition = "2018"
 
 homepage = "https://github.com/rust-netlink/netlink-packet-audit"
 keywords = ["netlink", "linux"]
 license = "MIT"
-readme = "../README.md"
+readme = "README.md"
 repository = "https://github.com/rust-netlink/netlink-packet-audit"
 description = "netlink packet types"
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# Rust audit netlink protocol
+
+The `netlink-packet-audit` crate provides netlink messages parsing for
+[audit][audit_man] protocol.
+
+[audit_man]: https://man7.org/linux/man-pages/man3/audit_open.3.html


### PR DESCRIPTION
=== Breaking changes
 - All public struct and enum are marked as `non_exhaustive`. Please check
   https://doc.rust-lang.org/reference/attributes/type_system.html for more
   detail. (5660d73)

=== New features
 - N/A

=== Bug fixes
 - N/A