### PR TITLE
New release 0.5.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,4 +30,4 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           files: lcov.info
-          fail_ci_if_error: true
+          fail_ci_if_error: false

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,14 @@
 # Changelog
+## [0.5.1] - 2023-07-10
+### Breaking changes
+ - N/A
+
+### New features
+ - N/A
+
+### Bug fixes
+ - Use latest rust-netlink crates. (d183103)
+
 ## [0.5.0] - 2023-01-28
 ### Breaking changes
  - All public struct and enum are marked as `non_exhaustive`. Please check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Corentin Henry <corentinhenry@gmail.com>"]
 name = "netlink-packet-audit"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2018"
 
 homepage = "https://github.com/rust-netlink/netlink-packet-audit"


### PR DESCRIPTION
=== Breaking changes
 - N/A

=== New features
 - N/A

=== Bug fixes
 - Use latest rust-netlink crates. (d183103)