### PR TITLE
Fix status message parsing on different kernels

### DIFF
--- a/src/status.rs
+++ b/src/status.rs
@@ -17,9 +17,10 @@ const RATE_LIMITING: Field = 16..20;
 const BACKLOG_LIMIT: Field = 20..24;
 const LOST: Field = 24..28;
 const BACKLOG: Field = 28..32;
+pub const MINIMAL_STATUS_MESSAGE_LEN: usize = BACKLOG.end;
 const FEATURE_BITMAP: Field = 32..36;
 const BACKLOG_WAIT_TIME: Field = 36..40;
-pub const STATUS_MESSAGE_LEN: usize = BACKLOG_WAIT_TIME.end;
+pub const MAXIMAL_STATUS_MESSAGE_LEN: usize = BACKLOG_WAIT_TIME.end;
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
 #[non_exhaustive]
@@ -39,10 +40,13 @@ pub struct StatusMessage {
     pub lost: u32,
     /// Messages waiting in queue
     pub backlog: u32,
+
+    // Starting here, those fields may not be present in older kernels, hence
+    // the use of Option.
     /// bitmap of kernel audit features
-    pub feature_bitmap: u32,
+    pub feature_bitmap: Option<u32>,
     /// Message queue wait timeout
-    pub backlog_wait_time: u32,
+    pub backlog_wait_time: Option<u32>,
 }
 
 impl StatusMessage {
@@ -72,10 +76,10 @@ impl<T: AsRef<[u8]>> StatusMessageBuffer<T> {
 
     fn check_buffer_length(&self) -> Result<(), DecodeError> {
         let len = self.buffer.as_ref().len();
-        if len < STATUS_MESSAGE_LEN {
+        if len < MINIMAL_STATUS_MESSAGE_LEN {
             return Err(format!(
                 "invalid StatusMessageBuffer buffer: length is {len} \
-                instead of {STATUS_MESSAGE_LEN}"
+                instead of at least {MINIMAL_STATUS_MESSAGE_LEN}"
             )
             .into());
         }
@@ -118,12 +122,22 @@ impl<T: AsRef<[u8]>> StatusMessageBuffer<T> {
         NativeEndian::read_u32(&self.buffer.as_ref()[BACKLOG])
     }
 
-    pub fn feature_bitmap(&self) -> u32 {
-        NativeEndian::read_u32(&self.buffer.as_ref()[FEATURE_BITMAP])
+    pub fn feature_bitmap(&self) -> Option<u32> {
+        let buf = self.buffer.as_ref();
+        if buf.len() < FEATURE_BITMAP.end {
+            None
+        } else {
+            Some(NativeEndian::read_u32(&buf[FEATURE_BITMAP]))
+        }
     }
 
-    pub fn backlog_wait_time(&self) -> u32 {
-        NativeEndian::read_u32(&self.buffer.as_ref()[BACKLOG_WAIT_TIME])
+    pub fn backlog_wait_time(&self) -> Option<u32> {
+        let buf = self.buffer.as_ref();
+        if buf.len() < BACKLOG_WAIT_TIME.end {
+            None
+        } else {
+            Some(NativeEndian::read_u32(&buf[BACKLOG_WAIT_TIME]))
+        }
     }
 }
 
@@ -161,17 +175,17 @@ impl<T: AsRef<[u8]> + AsMut<[u8]>> StatusMessageBuffer<T> {
     }
 
     pub fn set_feature_bitmap(&mut self, value: u32) {
-        NativeEndian::write_u32(
-            &mut self.buffer.as_mut()[FEATURE_BITMAP],
-            value,
-        )
+        let buf = &mut self.buffer.as_mut();
+        if buf.len() >= FEATURE_BITMAP.end {
+            NativeEndian::write_u32(&mut buf[FEATURE_BITMAP], value)
+        }
     }
 
     pub fn set_backlog_wait_time(&mut self, value: u32) {
-        NativeEndian::write_u32(
-            &mut self.buffer.as_mut()[BACKLOG_WAIT_TIME],
-            value,
-        )
+        let buf = &mut self.buffer.as_mut();
+        if buf.len() >= BACKLOG_WAIT_TIME.end {
+            NativeEndian::write_u32(&mut buf[BACKLOG_WAIT_TIME], value)
+        }
     }
 }
 
@@ -195,7 +209,7 @@ impl<T: AsRef<[u8]>> Parseable<StatusMessageBuffer<T>> for StatusMessage {
 
 impl Emitable for StatusMessage {
     fn buffer_len(&self) -> usize {
-        STATUS_MESSAGE_LEN
+        MAXIMAL_STATUS_MESSAGE_LEN
     }
 
     fn emit(&self, buffer: &mut [u8]) {
@@ -208,7 +222,11 @@ impl Emitable for StatusMessage {
         buffer.set_backlog_limit(self.backlog_limit);
         buffer.set_lost(self.lost);
         buffer.set_backlog(self.backlog);
-        buffer.set_feature_bitmap(self.feature_bitmap);
-        buffer.set_backlog_wait_time(self.backlog_wait_time);
+        if let Some(feature_bitmap) = self.feature_bitmap {
+            buffer.set_feature_bitmap(feature_bitmap);
+        }
+        if let Some(backlog_wait_time) = self.backlog_wait_time {
+            buffer.set_backlog_wait_time(backlog_wait_time);
+        }
     }
 }


### PR DESCRIPTION
First of all, thanks for this crate! I've been testing it in different environments and came upon an issue on older kernel versions. The StatusMessage has different length and fields depending on the kernel version, and it failed to parse correctly on centos7 for example, because of a received payload that was too short.

This PR does two things:
- it fixes the parsing on older kernel versions. I've looked at a 2.6.32 one and up to a 6.4.3 one
- it adds a new field added since the 5.9 kernel

`audit_status` struct on a 2.6.32 (centos6):

![image](https://github.com/rust-netlink/netlink-packet-audit/assets/5676008/993546d6-68eb-46a5-a488-2d885446d7ef)

`audit_status` struct on a 6.4.3 (arch):

![image](https://github.com/rust-netlink/netlink-packet-audit/assets/5676008/42c5be07-d92e-4557-8c2e-e82a38240f49)
