### PR TITLE
Do not log warnings on expected message length corrections

### DIFF
--- a/src/codec.rs
+++ b/src/codec.rs
@@ -45,7 +45,9 @@ impl NetlinkMessageCodec for NetlinkAuditCodec {
             let src_len = src.len();
             let len = match NetlinkBuffer::new_checked(src.as_mut()) {
                 Ok(mut buf) => {
-                    if (src_len as isize - buf.length() as isize) <= 16 {
+                    if src_len != buf.length() as usize
+                        && (src_len as isize - buf.length() as isize) <= 16
+                    {
                         // The audit messages are sometimes truncated,
                         // because the length specified in the header,
                         // does not take the header itself into
@@ -70,11 +72,9 @@ impl NetlinkMessageCodec for NetlinkAuditCodec {
                         //   entire messages, so we know that if those extra
                         //   bytes do not belong to another message, they belong
                         //   to this one.
-                        warn!("found what looks like a truncated audit packet");
-                        // also write correct length to buffer so parsing does
-                        // not fail:
-                        warn!(
-                            "setting packet length to {} instead of {}",
+                        trace!(
+                            "found what looks like a truncated audit packet, \
+                             setting packet length to {} instead of {}",
                             src_len,
                             buf.length()
                         );


### PR DESCRIPTION
When correcting the length of a received message, warning logs are emitted. This is annoying because:

- they are emitted even when the length is correct, ie `src_len == buffer.len()`, due to how the condition is written
- they are emitted when `src_len = buffer.len() + 16`, which means the buffer does not contain the length of the header, and which happens on every message on my computer.

As written in the comment doc, correcting the length of the message is expected, and really should not emit warning logs. So:

- Properly check the `src_len == buffer.len()` situation to not emit a log in this case
- Change the level from warn to trace (even on debug, that would spam logs for every single message received).

For example, here is one trace on my machine, setting the logger at warn level, just as I connect to the audit socket:

```
[2023-07-24 09:12:48.578099 +00:00] WARN [netlink_packet_audit::codec] found what looks like a truncated audit packet
[2023-07-24 09:12:48.578123 +00:00] WARN [netlink_packet_audit::codec] setting packet length to 36 instead of 36
[2023-07-24 09:12:48.578177 +00:00] WARN [netlink_packet_audit::codec] found what looks like a truncated audit packet
[2023-07-24 09:12:48.578226 +00:00] WARN [netlink_packet_audit::codec] setting packet length to 96 instead of 80
[2023-07-24 09:12:48.578286 +00:00] WARN [netlink_packet_audit::codec] found what looks like a truncated audit packet
[2023-07-24 09:12:48.578308 +00:00] WARN [netlink_packet_audit::codec] setting packet length to 97 instead of 81
[2023-07-24 09:12:48.578345 +00:00] WARN [netlink_packet_audit::codec] found what looks like a truncated audit packet
[2023-07-24 09:12:48.578366 +00:00] WARN [netlink_packet_audit::codec] setting packet length to 393 instead of 377
[2023-07-24 09:12:48.578404 +00:00] WARN [netlink_packet_audit::codec] found what looks like a truncated audit packet
[2023-07-24 09:12:48.578424 +00:00] WARN [netlink_packet_audit::codec] setting packet length to 76 instead of 60
[2023-07-24 09:12:48.578461 +00:00] WARN [netlink_packet_audit::codec] found what looks like a truncated audit packet
[2023-07-24 09:12:48.578481 +00:00] WARN [netlink_packet_audit::codec] setting packet length to 312 instead of 296
[2023-07-24 09:12:48.578520 +00:00] WARN [netlink_packet_audit::codec] found what looks like a truncated audit packet
[2023-07-24 09:12:48.578540 +00:00] WARN [netlink_packet_audit::codec] setting packet length to 46 instead of 30
[2023-07-24 09:12:48.578758 +00:00] WARN [netlink_packet_audit::codec] found what looks like a truncated audit packet
[2023-07-24 09:12:48.578783 +00:00] WARN [netlink_packet_audit::codec] setting packet length to 60 instead of 60
[2023-07-24 09:12:48.578951 +00:00] WARN [netlink_packet_audit::codec] found what looks like a truncated audit packet
[2023-07-24 09:12:48.578976 +00:00] WARN [netlink_packet_audit::codec] setting packet length to 36 instead of 36
[2023-07-24 09:12:48.579025 +00:00] WARN [netlink_packet_audit::codec] found what looks like a truncated audit packet
[2023-07-24 09:12:48.579047 +00:00] WARN [netlink_packet_audit::codec] setting packet length to 96 instead of 80
[2023-07-24 09:12:48.579085 +00:00] WARN [netlink_packet_audit::codec] found what looks like a truncated audit packet
[2023-07-24 09:12:48.579104 +00:00] WARN [netlink_packet_audit::codec] setting packet length to 99 instead of 83
[2023-07-24 09:12:48.579140 +00:00] WARN [netlink_packet_audit::codec] found what looks like a truncated audit packet
[2023-07-24 09:12:48.579160 +00:00] WARN [netlink_packet_audit::codec] setting packet length to 108 instead of 92
[2023-07-24 09:12:48.579198 +00:00] WARN [netlink_packet_audit::codec] found what looks like a truncated audit packet
[2023-07-24 09:12:48.579217 +00:00] WARN [netlink_packet_audit::codec] setting packet length to 106 instead of 90
[2023-07-24 09:12:48.579441 +00:00] WARN [netlink_packet_audit::codec] found what looks like a truncated audit packet
[2023-07-24 09:12:48.579467 +00:00] WARN [netlink_packet_audit::codec] setting packet length to 1076 instead of 1076
[2023-07-24 09:12:48.579512 +00:00] WARN [netlink_packet_audit::codec] found what looks like a truncated audit packet
[2023-07-24 09:12:48.579534 +00:00] WARN [netlink_packet_audit::codec] setting packet length to 97 instead of 81