### PR TITLE
fix: parse AUDIT_REPLACE properly

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -79,6 +79,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> ParseableParametrized<AuditBuffer<&'a T>, u16>
                 let buf = RuleBuffer::new_checked(buf.inner()).context(err)?;
                 ListRules(Some(RuleMessage::parse(&buf).context(err)?))
             }
+            AUDIT_REPLACE => Replace(buf.inner().to_vec()),
             i if (AUDIT_EVENT_MESSAGE_MIN..AUDIT_EVENT_MESSAGE_MAX)
                 .contains(&i) =>
             {


### PR DESCRIPTION
The AUDIT_REPLACE message payload is a uint32 number, which is not an ascii string. This causes parsing issues when such a message is parsed, and one of the byte is >= 0x7F

There is two solutions for this afaict:

- Parse the AUDIT_REPLACE message on its own, making minimal changes.
- Change the AuditMessage Event/Other enums to store a Vec<u8> instead of a String.

I picked the first one, to have minimal impact on existing code. However, the second solution imho would be a much better solution. This crate should not expect every message to a utf-8, which is a weird assumption. Its much better to let the caller decide how to parse the payloads, and not have errors when messages have non utf-8 compatible bytes.