### PR TITLE
New release 0.6.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,14 @@
 # Changelog
+## [0.6.0] - 2025-08-27
+### Breaking changes
+ - Use netlink-packet-core 0.8. (a78cd33)
+
+### New features
+ - N/A
+
+### Bug fixes
+ - N/A
+
 ## [0.5.1] - 2023-07-10
 ### Breaking changes
  - N/A

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 authors = ["Corentin Henry <corentinhenry@gmail.com>"]
 name = "netlink-packet-audit"
-version = "0.5.1"
-edition = "2018"
+version = "0.6.1"
+edition = "2021"
 
 homepage = "https://github.com/rust-netlink/netlink-packet-audit"
 keywords = ["netlink", "linux"]


### PR DESCRIPTION
=== Breaking changes
 - Use netlink-packet-core 0.8. (a78cd33)

=== New features
 - N/A

=== Bug fixes
 - N/A